### PR TITLE
Added default parameters in metadata urls to ensure ISO compliance

### DIFF
--- a/js/selection/controller.js
+++ b/js/selection/controller.js
@@ -6709,6 +6709,22 @@ $scope.sendRunRequest = function() {
 			}
 		} else {
 			if (remoteFile != "") {
+				if ($scope.select.typeResource == "metadata"){
+				    var params = remoteFile.split("?");
+				    var properties=[]
+				    params=params[1]
+				    params=params.split("&")
+				    var i=0
+				    while (i<params.length){
+				        var tempParams=params[i]
+				        properties.push(tempParams.split("=")[0])
+				        i=i+1
+				        }
+				    if(!properties.includes("outputSchema")){
+				        remoteFile=remoteFile+"&outputSchema=http://www.isotc211.org/2005/gmd"}
+				    if(!properties.includes("elementSetName")){
+				        remoteFile=remoteFile+"&elementSetName=full"}
+               		}
 				var txtUsername = $("#text-input-username").val();
 				var txtPassword = $("#text-input-password").val();
 				if ($('#file-upload-id').text().includes("Service URL")) {


### PR DESCRIPTION
According to #19  , it is included the following parameters in metadata requests using url
* outputSchema=http://www.isotc211.org/2005/gmd
* elementSetName=full
In case the parameters are introduced by the user, they are preserved and no modified.
