### PR TITLE
Added VALIDATOR version as var and introduced as comment in home head

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -2,6 +2,8 @@ var captchaEnabled = true;
 var betaBanner = false;
 var labelStaging = true;
 var environment = "STAGING";
+var validatorVersionLabel = "2024.0.1 (2024-03-05)";
+
 // STAGING
 var serverURL = "http://staging-inspire-validator.eu-west-1.elasticbeanstalk.com/validator/v2/";
 var serverRealURL = "http://staging-inspire-validator.eu-west-1.elasticbeanstalk.com/validator/v2/";

--- a/js/home/controller.js
+++ b/js/home/controller.js
@@ -9,3 +9,13 @@ if (betaBanner == true) {
 if (labelStaging == true) {
 	$(document).prop('title', "[STAGING] " + $(document).prop('title'));
 }
+
+//Show version label if exists
+if (validatorVersionLabel !== null && validatorVersionLabel !== undefined) {
+
+	// Create a comment with the version label
+	var commentNode = document.createComment('Validator version: ' + validatorVersionLabel);
+
+	// Insert the comment node right at the start of the head
+	document.head.insertBefore(commentNode, document.head.firstChild);
+}


### PR DESCRIPTION
According to the discussion https://github.com/INSPIRE-MIF/helpdesk-validator/discussions/1035, the INSPIRE Reference Validator version is incorporated in the UI in a commented html string so an advanced user can consult it.