### PR TITLE
Removed Metadata v1.3 DEPRECATED

### DIFF
--- a/js/rerun/controller.js
+++ b/js/rerun/controller.js
@@ -310,9 +310,6 @@ ngApp.controller('myValidatorController', function($scope) {
 			testSuiteId = testSuiteId.replace(".json", "");
 			//testSuiteId = "EID" + testSuiteId;
 			var testSuiteDesc = testSuiteId;
-			if (testSuiteId == "EIDe3500038-e37c-4dcf-806c-6bc82d585b3b") testSuiteDesc = "Conformance Class XML encoding of ISO 19115/19119 metadata";
-			if (testSuiteId == "EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c") testSuiteDesc = "Conformance Class INSPIRE Profile based on EN ISO 19115 and EN ISO 19119";
-			if (testSuiteId == "EID9a31ecfc-6673-43c0-9a31-b4595fb53a98") testSuiteDesc = "Conformance class Metadata for interoperability";
 			if (testSuiteId == "EID59692c11-df86-49ad-be7f-94a1e1ddd8da") testSuiteDesc = "Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records";
 			if (testSuiteId == "EIDe4a95862-9cc9-436b-9fdd-a0115d342350") testSuiteDesc = "Conformance Class 1: Baseline metadata for data sets and data set series";
 			if (testSuiteId == "EID2be1480a-fe42-40b2-9420-eb0e69385c80") testSuiteDesc = "Conformance Class 2: INSPIRE data sets and data set series interoperability metadata";

--- a/js/results/controller.js
+++ b/js/results/controller.js
@@ -639,9 +639,6 @@ ngApp.controller('myValidatorController', function($scope) {
 			testSuiteId = testSuiteId.replace(".json", "");
 			if (testSuiteId.substring(0,3) != "EID") testSuiteId = "EID" + testSuiteId;
 			var testSuiteDesc = testSuiteId;
-			if (testSuiteId == "EIDe3500038-e37c-4dcf-806c-6bc82d585b3b") testSuiteDesc = "Conformance Class XML encoding of ISO 19115/19119 metadata";
-			if (testSuiteId == "EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c") testSuiteDesc = "Conformance Class INSPIRE Profile based on EN ISO 19115 and EN ISO 19119";
-			if (testSuiteId == "EID9a31ecfc-6673-43c0-9a31-b4595fb53a98") testSuiteDesc = "Conformance class Metadata for interoperability";
 			if (testSuiteId == "EID59692c11-df86-49ad-be7f-94a1e1ddd8da") testSuiteDesc = "Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records";
 			if (testSuiteId == "EIDe4a95862-9cc9-436b-9fdd-a0115d342350") testSuiteDesc = "Conformance Class 1: Baseline metadata for data sets and data set series";
 			if (testSuiteId == "EID2be1480a-fe42-40b2-9420-eb0e69385c80") testSuiteDesc = "Conformance Class 2: INSPIRE data sets and data set series interoperability metadata";
@@ -1062,7 +1059,7 @@ ngApp.controller('myValidatorController', function($scope) {
 				// Search by resource type
 				if ($scope.searchParameters.resourceType != 'any') {
 					keyFoundResources = false;
-					if ($scope.searchParameters.resourceType == "metadata") var arrayTestSuiteId = ["EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c", "EID9a31ecfc-6673-43c0-9a31-b4595fb53a98", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EIDe4a95862-9cc9-436b-9fdd-a0115d342350", "EID2be1480a-fe42-40b2-9420-eb0e69385c80", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EID8f869e23-c9e9-4e86-8dca-be30ff421229", "EID606587df-65a8-4b7b-9eee-e0d94daaa42a", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EID8f869e23-c9e9-4e86-8dca-be30ff421229", "EID8db54d8a-8578-4959-b891-5394d9f53a28", "EID7514777a-6cb8-499c-acd5-912496dc84e9", "EIDa593a7ad-42d9-46d0-985d-9dff3e684428"];
+					if ($scope.searchParameters.resourceType == "metadata") var arrayTestSuiteId = ["EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EIDe4a95862-9cc9-436b-9fdd-a0115d342350", "EID2be1480a-fe42-40b2-9420-eb0e69385c80", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EID8f869e23-c9e9-4e86-8dca-be30ff421229", "EID606587df-65a8-4b7b-9eee-e0d94daaa42a", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EID8f869e23-c9e9-4e86-8dca-be30ff421229", "EID8db54d8a-8578-4959-b891-5394d9f53a28", "EID7514777a-6cb8-499c-acd5-912496dc84e9", "EIDa593a7ad-42d9-46d0-985d-9dff3e684428"];
 					if ($scope.searchParameters.resourceType == "viewservice") var arrayTestSuiteId = ["EIDeec9d674-d94b-4d8d-b744-1309c6cae1d2", "EID550ceacf-b3cb-47a0-b2dd-d3edb18344a9"];
 					if ($scope.searchParameters.resourceType == "downloadservice") var arrayTestSuiteId = ["EIDed2d3501-d700-4ff9-b9bf-070dece8ddbd", "EID174edf55-699b-446c-968c-1892a4d8d5bd", "EID11571c92-3940-4f42-a6cd-5e2b1c6f4d93", "EID074570ad-d720-47b3-af79-d54201793404", "EID0ff73873-5601-41ff-8d92-3fb1fbba3cf2"];
 					if ($scope.searchParameters.resourceType == "discoveryservice") var arrayTestSuiteId = ["EIDc837298f-a10e-42d1-88f2-f1415cbbb463"];

--- a/js/selection/controller.js
+++ b/js/selection/controller.js
@@ -110,10 +110,6 @@ ngApp.controller('myValidatorController', function($scope) {
 		$scope.restservice.testsuiteid = [];
 		// METADATA
 		if ($scope.select.typeResource == "metadata") {
-			if (($scope.select.typeResource == "metadata") && ($scope.select.metadataVersion == "1.3") && ($scope.select.metadataRecords == "-") && ($scope.select.metadataAdvancedOptions === false)) $scope.restservice.testsuiteid = "EID9a31ecfc-6673-43c0-9a31-b4595fb53a98";
-			if (($scope.select.typeResource == "metadata") && ($scope.select.metadataVersion == "1.3") && ($scope.select.metadataRecords == "-") && ($scope.select.metadataAdvancedOptions === true) && ($scope.select.metadataAdvancedInteroperability == true)) $scope.restservice.testsuiteid = "EID9a31ecfc-6673-43c0-9a31-b4595fb53a98";
-			if (($scope.select.typeResource == "metadata") && ($scope.select.metadataVersion == "1.3") && ($scope.select.metadataRecords == "-") && ($scope.select.metadataAdvancedOptions === true) && ($scope.select.metadataAdvancedInteroperability == false) && ($scope.select.metadataAdvancedInspireProfile == true)) $scope.restservice.testsuiteid = "EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c";
-			if (($scope.select.typeResource == "metadata") && ($scope.select.metadataVersion == "1.3") && ($scope.select.metadataRecords == "-") && ($scope.select.metadataAdvancedOptions === true) && ($scope.select.metadataAdvancedInteroperability == false) && ($scope.select.metadataAdvancedInspireProfile == false)) $scope.restservice.testsuiteid = "EIDe3500038-e37c-4dcf-806c-6bc82d585b3b";
 			if (($scope.select.typeResource == "metadata") && ($scope.select.metadataVersion == "2.0") && ($scope.select.metadataRecords == "metadata_dataset") && ($scope.select.metadataAdvancedOptions === false)) {
 				arrayTestsuiteid = [];
 				arrayTestsuiteid.push("EID2be1480a-fe42-40b2-9420-eb0e69385c80");
@@ -740,9 +736,6 @@ ngApp.controller('myValidatorController', function($scope) {
 		var testSuiteId = $scope.restservice.testsuiteid;
 		var testSuiteDesc = "-";
 		// METADATA
-		if (testSuiteId == "EIDe3500038-e37c-4dcf-806c-6bc82d585b3b") testSuiteDesc = "Conformance Class XML encoding of ISO 19115/19119 metadata";
-		if (testSuiteId == "EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c") testSuiteDesc = "Conformance Class INSPIRE Profile based on EN ISO 19115 and EN ISO 19119";
-		if (testSuiteId == "EID9a31ecfc-6673-43c0-9a31-b4595fb53a98") testSuiteDesc = "Conformance class Metadata for interoperability";
 		if (testSuiteId == "EID59692c11-df86-49ad-be7f-94a1e1ddd8da") testSuiteDesc = "Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records";
 		if (testSuiteId == "EIDe4a95862-9cc9-436b-9fdd-a0115d342350") testSuiteDesc = "Conformance Class 1: Baseline metadata for data sets and data set series";
 		if (testSuiteId == "EID2be1480a-fe42-40b2-9420-eb0e69385c80") testSuiteDesc = "Conformance Class 2: INSPIRE data sets and data set series interoperability metadata";
@@ -773,9 +766,6 @@ ngApp.controller('myValidatorController', function($scope) {
 		if (testSuiteId == "EID499937ea-0590-42d2-bd7a-1cafff35ecdb") testSuiteDesc = "Conformance Class Information accessibility";
 		if (testSuiteId == "EID63f586f0-080c-493b-8ca2-9919427440cc") testSuiteDesc = "Conformance Class Reference systems";
 		if (Array.isArray(testSuiteId)) {
-			if (testSuiteId.includes("EIDe3500038-e37c-4dcf-806c-6bc82d585b3b")) testSuiteDesc = "Conformance Class XML encoding of ISO 19115/19119 metadata";
-			if (testSuiteId.includes("EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c")) testSuiteDesc = "Conformance Class INSPIRE Profile based on EN ISO 19115 and EN ISO 19119";
-			if (testSuiteId.includes("EID9a31ecfc-6673-43c0-9a31-b4595fb53a98")) vtestSuiteDesc = "Conformance class Metadata for interoperability";
 			if (testSuiteId.includes("EID59692c11-df86-49ad-be7f-94a1e1ddd8da")) testSuiteDesc = "Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records";
 			if (testSuiteId.includes("EIDe4a95862-9cc9-436b-9fdd-a0115d342350")) testSuiteDesc = "Conformance Class 1: Baseline metadata for data sets and data set series";
 			if (testSuiteId.includes("EID2be1480a-fe42-40b2-9420-eb0e69385c80")) testSuiteDesc = "Conformance Class 2: INSPIRE data sets and data set series interoperability metadata";

--- a/js/testrun/controller.js
+++ b/js/testrun/controller.js
@@ -606,9 +606,6 @@ ngApp.controller('myValidatorController', function($scope) {
 			console.log(testSuiteId.substring(0,2));
 			if (testSuiteId.substring(0,3) != "EID") testSuiteId = "EID" + testSuiteId;
 			var testSuiteDesc = testSuiteId;
-			if (testSuiteId == "EIDe3500038-e37c-4dcf-806c-6bc82d585b3b") testSuiteDesc = "Conformance Class XML encoding of ISO 19115/19119 metadata";
-			if (testSuiteId == "EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c") testSuiteDesc = "Conformance Class INSPIRE Profile based on EN ISO 19115 and EN ISO 19119";
-			if (testSuiteId == "EID9a31ecfc-6673-43c0-9a31-b4595fb53a98") testSuiteDesc = "Conformance class Metadata for interoperability";
 			if (testSuiteId == "EID59692c11-df86-49ad-be7f-94a1e1ddd8da") testSuiteDesc = "Common Requirements for ISO/TC 19139:2007 based INSPIRE metadata records";
 			if (testSuiteId == "EIDe4a95862-9cc9-436b-9fdd-a0115d342350") testSuiteDesc = "Conformance Class 1: Baseline metadata for data sets and data set series";
 			if (testSuiteId == "EID2be1480a-fe42-40b2-9420-eb0e69385c80") testSuiteDesc = "Conformance Class 2: INSPIRE data sets and data set series interoperability metadata";
@@ -1005,7 +1002,7 @@ ngApp.controller('myValidatorController', function($scope) {
 				// Search by resource type
 				if ($scope.searchParameters.resourceType != 'any') {
 					keyFoundResources = false;
-					if ($scope.searchParameters.resourceType == "metadata") var arrayTestSuiteId = ["EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c", "EID9a31ecfc-6673-43c0-9a31-b4595fb53a98", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EIDe4a95862-9cc9-436b-9fdd-a0115d342350", "EID2be1480a-fe42-40b2-9420-eb0e69385c80", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EID8f869e23-c9e9-4e86-8dca-be30ff421229", "EID606587df-65a8-4b7b-9eee-e0d94daaa42a", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EID8f869e23-c9e9-4e86-8dca-be30ff421229", "EID8db54d8a-8578-4959-b891-5394d9f53a28", "EID7514777a-6cb8-499c-acd5-912496dc84e9", "EIDa593a7ad-42d9-46d0-985d-9dff3e684428"];
+					if ($scope.searchParameters.resourceType == "metadata") var arrayTestSuiteId = ["EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EIDe4a95862-9cc9-436b-9fdd-a0115d342350", "EID2be1480a-fe42-40b2-9420-eb0e69385c80", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EID8f869e23-c9e9-4e86-8dca-be30ff421229", "EID606587df-65a8-4b7b-9eee-e0d94daaa42a", "EID59692c11-df86-49ad-be7f-94a1e1ddd8da", "EID8f869e23-c9e9-4e86-8dca-be30ff421229", "EID8db54d8a-8578-4959-b891-5394d9f53a28", "EID7514777a-6cb8-499c-acd5-912496dc84e9", "EIDa593a7ad-42d9-46d0-985d-9dff3e684428"];
 					if ($scope.searchParameters.resourceType == "viewservice") var arrayTestSuiteId = ["EIDeec9d674-d94b-4d8d-b744-1309c6cae1d2", "EID550ceacf-b3cb-47a0-b2dd-d3edb18344a9"];
 					if ($scope.searchParameters.resourceType == "downloadservice") var arrayTestSuiteId = ["EIDed2d3501-d700-4ff9-b9bf-070dece8ddbd", "EID174edf55-699b-446c-968c-1892a4d8d5bd", "EID11571c92-3940-4f42-a6cd-5e2b1c6f4d93", "EID074570ad-d720-47b3-af79-d54201793404", "EID0ff73873-5601-41ff-8d92-3fb1fbba3cf2"];
 					if ($scope.searchParameters.resourceType == "discoveryservice") var arrayTestSuiteId = ["EIDc837298f-a10e-42d1-88f2-f1415cbbb463"];

--- a/test-selection/index.html
+++ b/test-selection/index.html
@@ -261,8 +261,10 @@
         </div>
 
         <!-- METADATA -->
-        <div id="metadata-group" ng-show="select.typeResource == 'metadata'">
-          <div id="metadata-version-group" class="radio-group">
+	<div id="metadata-group" ng-show="select.typeResource == 'metadata'">
+	  <input type="hidden" name="metadata-version" id="metadata-version-2" value="2.0">
+          <!--
+	  <div id="metadata-version-group" class="radio-group">
             <fieldset aria-describedby="metadata-version-1" class="ecl-form-group">
               <legend class="ecl-form-label">Select the Technical Guidelines version</legend>
                 <div class="ecl-radio"><input type="radio" id="metadata-version-1" name="metadata-version" class="ecl-radio__input"
@@ -275,6 +277,7 @@
                 </div>
             </fieldset>
           </div>
+	  -->
 
           <div id="metadata-records-group" class="radio-group" ng-show="select.visibleMetadataRecords">
             <fieldset aria-describedby="metadata-records-1" class="ecl-form-group">
@@ -301,6 +304,7 @@
                   </svg></span></button>
               <div class="ecl-expandable__content" id="metadata-advanced-options-content" hidden="">
                 <!-- 1.3 -->
+		<!--
                 <fieldset aria-describedby="checkbox-default-helper" class="ecl-form-group" ng-show="select.metadataVersion == '1.3'">
                   <legend class="ecl-form-label"><br/>Select the conformance classes to be assessed</legend>
                   <div class="ecl-checkbox"><input type="checkbox" class="ecl-checkbox__input" id="metadata-13-options-0"
@@ -325,6 +329,7 @@
                         </svg></span>Metadata for interoperability (<a target="_linkTest" href="http://inspire.ec.europa.eu/id/ats/data/master/interoperability-metadata">source</a>)</label>
                   </div>
                 </fieldset>
+		-->
                 <!-- 2.0 & dataset -->
                 <fieldset aria-describedby="checkbox-default-helper" class="ecl-form-group" ng-show="select.metadataVersion == '2.0' && select.metadataRecords == 'metadata_dataset'">
                   <legend class="ecl-form-label"><br/>Select the conformance classes to be assessed</legend>


### PR DESCRIPTION
As discussed at our last meeting, I created a new branch named "issue-97" to remove the ability to select and use metadata v1.3 (which were previously in a deprecated state). Of course, in addition to removing the selection from the "Test Selection" page, I also removed the identifiers no longer used and previously assigned to the removed metadata. Here the list of the EID removed:

- EID9a31ecfc-6673-43c0-9a31-b4595fb53a98
- EID9a31ecfc-6673-43c0-9a31-b4595fb53a98
- EIDec7323d5-d8f0-4cfe-b23a-b826df86d58c
- EIDe3500038-e37c-4dcf-806c-6bc82d585b3b

I remain available for any further explanation regarding this change.