### PR TITLE
issue 102. change urls in config.js to new staging urls

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -2,7 +2,7 @@ var captchaEnabled = true;
 var betaBanner = false;
 var labelStaging = true;
 var environment = "STAGING";
-var validatorVersionLabel = "2024.2 (2024-06-11)";
+var validatorVersionLabel = "2024.2 (2024-09-15)";
 
 // STAGING
 var serverURL = "https://inspire.ec.europa.eu/validator-staging-api/";

--- a/js/config.js
+++ b/js/config.js
@@ -2,7 +2,7 @@ var captchaEnabled = true;
 var betaBanner = false;
 var labelStaging = true;
 var environment = "STAGING";
-var validatorVersionLabel = "2024.2 (2024-09-15)";
+var validatorVersionLabel = "2024.3 (2024-09-15)";
 
 // STAGING
 var serverURL = "https://inspire.ec.europa.eu/validator-staging-api/";

--- a/js/config.js
+++ b/js/config.js
@@ -2,16 +2,13 @@ var captchaEnabled = true;
 var betaBanner = false;
 var labelStaging = true;
 var environment = "STAGING";
-var validatorVersionLabel = "2024.0.1 (2024-03-05)";
+var validatorVersionLabel = "2024.2 (2024-06-11)";
 
 // STAGING
-var serverURL = "http://staging-inspire-validator.eu-west-1.elasticbeanstalk.com/validator/v2/";
-var serverRealURL = "http://staging-inspire-validator.eu-west-1.elasticbeanstalk.com/validator/v2/";
-var serverDirectURL = "http://staging-inspire-validator.eu-west-1.elasticbeanstalk.com/validator/v2/";
-var serverCaptchaURL = "http://staging-inspire-validator.eu-west-1.elasticbeanstalk.com/validator/captcha/verify.php";
+var serverURL = "https://inspire.ec.europa.eu/validator-staging-api/";
+var serverRealURL = "https://inspire.ec.europa.eu/validator-staging-api/";
+var serverDirectURL = "https://inspire.ec.europa.eu/validator-staging-api/";
+var serverCaptchaURL = "https://inspire.ec.europa.eu/validator-staging/captcha/verify";
 var serverToken = "";
-var swaggerURL = "http://staging-inspire-validator.eu-west-1.elasticbeanstalk.com/validator/swagger-ui.html";
+var swaggerURL = "https://inspire.ec.europa.eu/validator-staging/swagger-ui.html";
 var timeUpMessage= "";
-// Production
-//var swaggerURL = "https://inspire.ec.europa.eu/validator/swagger-ui.html"
-//var timeUpMessage="Test Reports are kept for a maximum of 48 hours.";


### PR DESCRIPTION
Change the urls inside the js/config.js so urls of the staging UI point into the new official staging urls.

linked to [issue 102](https://github.com/inspire-eu-validation/INSPIRE-Validator-UI/issues/102)