### PR TITLE
Modified 'staging intance' label

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -167,8 +167,9 @@
                                 <ul class="ecl-menu__sublist">
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
                                             class="ecl-menu__sublink">Other instances</span></li>
-                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a onclick= "location.href=stagingURL" href="#"
-                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a></li>
+                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a id="showStaging" onclick= "location.href=stagingURL" href="#"
+                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a>
+                                        <a id="showProd" onclick= "location.href=productionURL" href="#" class="ecl-link ecl-link--standalone ecl-menu__sublink">Production instance</a></li><li></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
@@ -452,6 +453,13 @@
       $("#titleWebPage").show();
       $("#titleWebPageHeader").show();
     }
+     if (environment === 'STAGING') {
+		$("#showProd").show();
+		$("#showStaging").hide();
+	  } else if (environment === 'PROD') {
+	    $("#showProd").hide();
+		$("#showStaging").show();
+	  }
     </script>
     <script src="../js/menu.js"></script>
   </body>

--- a/accessibilitystatement.html
+++ b/accessibilitystatement.html
@@ -161,8 +161,9 @@
                             <ul class="ecl-menu__sublist">
                                 <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
                                         class="ecl-menu__sublink">Other instances</span></li>
-                                <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a onclick= "location.href=stagingURL" href="#"
-                                                                                                                            class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a></li>
+                                <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a id="showStaging" onclick= "location.href=stagingURL" href="#"
+                                                                                                                            class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a>
+                                    <a id="showProd" onclick= "location.href=productionURL" href="#" class="ecl-link ecl-link--standalone ecl-menu__sublink">Production instance</a></li><li></li>
                                 <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                 <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                 <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
@@ -463,6 +464,13 @@
     document.addEventListener('DOMContentLoaded', function() {
     ECL.autoInit();
 });
+ if (environment === 'STAGING') {
+		$("#showProd").show();
+		$("#showStaging").hide();
+	  } else if (environment === 'PROD') {
+	    $("#showProd").hide();
+		$("#showStaging").show();
+	  }
 </script>
 <script src="js/menu.js"></script>
 <link rel="stylesheet" href="home/style.css">

--- a/home/index.html
+++ b/home/index.html
@@ -170,8 +170,9 @@
                                 <ul class="ecl-menu__sublist">
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
                                             class="ecl-menu__sublink">Other instances</span></li>
-                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a onclick= "location.href=stagingURL" href="#"
-                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a></li><li></li>
+                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a id="showStaging" onclick= "location.href=stagingURL" href="#"
+                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a>
+                                    <a id="showProd" onclick= "location.href=productionURL" href="#" class="ecl-link ecl-link--standalone ecl-menu__sublink">Production instance</a></li><li></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
@@ -461,6 +462,13 @@
 	  if (labelStaging == true) {
 		$("#titleWebPage").show();
 		$("#titleWebPageHeader").show();
+	  }
+	  if (environment === 'STAGING') {
+		$("#showProd").show();
+		$("#showStaging").hide();
+	  } else if (environment === 'PROD') {
+	    $("#showProd").hide();
+		$("#showStaging").show();
 	  }
     </script>
     <script src="../js/menu.js"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -4,6 +4,7 @@ var labelStaging = true;
 var environment = "STAGING";
 var validatorVersionLabel = "2024.3 (2024-09-15)";
 var stagingURL = "https://inspire.ec.europa.eu/validator-staging/home/index.html";
+var productionURL = "https://inspire.ec.europa.eu/validator/home/index.html";
 
 // STAGING
 var serverURL = "https://inspire.ec.europa.eu/validator-staging-api/";

--- a/test-reports/details.html
+++ b/test-reports/details.html
@@ -141,8 +141,9 @@
                                 <ul class="ecl-menu__sublist">
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
                                             class="ecl-menu__sublink">Other instances</span></li>
-                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a onclick= "location.href=stagingURL" href="#"
-                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a></li>
+                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a id="showStaging" onclick= "location.href=stagingURL" href="#"
+                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a>
+                                        <a id="showProd" onclick= "location.href=productionURL" href="#" class="ecl-link ecl-link--standalone ecl-menu__sublink">Production instance</a></li><li></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
@@ -341,6 +342,13 @@
 
     <script>
       ECL.autoInit();
+       if (environment === 'STAGING') {
+		$("#showProd").show();
+		$("#showStaging").hide();
+	  } else if (environment === 'PROD') {
+	    $("#showProd").hide();
+		$("#showStaging").show();
+	  }
     </script>
   </body>
 </html>

--- a/test-reports/index.html
+++ b/test-reports/index.html
@@ -150,8 +150,9 @@
                                 <ul class="ecl-menu__sublist">
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
                                             class="ecl-menu__sublink">Other instances</span></li>
-                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a onclick= "location.href=stagingURL" href=""
-                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a></li>
+                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a id="showStaging" onclick= "location.href=stagingURL" href="#"
+                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a>
+                                        <a id="showProd" onclick= "location.href=productionURL" href="#" class="ecl-link ecl-link--standalone ecl-menu__sublink">Production instance</a></li><li></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
@@ -578,6 +579,13 @@
 
     <script>
       ECL.autoInit();
+       if (environment === 'STAGING') {
+		$("#showProd").show();
+		$("#showStaging").hide();
+	  } else if (environment === 'PROD') {
+	    $("#showProd").hide();
+		$("#showStaging").show();
+	  }
     </script>
     <script src="../js/menu.js"></script>
   </body>

--- a/test-rerun/index.html
+++ b/test-rerun/index.html
@@ -151,8 +151,9 @@
                                 <ul class="ecl-menu__sublist">
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
                                             class="ecl-menu__sublink">Other instances</span></li>
-                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a onclick= "location.href=stagingURL" href="#"
-                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a></li>
+                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a id="showStaging" onclick= "location.href=stagingURL" href="#"
+                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a>
+                                        <a id="showProd" onclick= "location.href=productionURL" href="#" class="ecl-link ecl-link--standalone ecl-menu__sublink">Production instance</a></li><li></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
@@ -442,6 +443,13 @@
 
     <script>
       ECL.autoInit();
+       if (environment === 'STAGING') {
+		$("#showProd").show();
+		$("#showStaging").hide();
+	  } else if (environment === 'PROD') {
+	    $("#showProd").hide();
+		$("#showStaging").show();
+	  }
     </script>
     <script src="../js/menu.js"></script>
   </body>

--- a/test-run/index.html
+++ b/test-run/index.html
@@ -149,8 +149,9 @@
                                 <ul class="ecl-menu__sublist">
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
                                             class="ecl-menu__sublink">Other instances</span></li>
-                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a onclick= "location.href=stagingURL" href="#"
-                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a></li>
+                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a id="showStaging" onclick= "location.href=stagingURL" href="#"
+                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a>
+                                        <a id="showProd" onclick= "location.href=productionURL" href="#" class="ecl-link ecl-link--standalone ecl-menu__sublink">Production instance</a></li><li></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
@@ -524,6 +525,13 @@
 <div class="balloonMessageRed" id="hidingMessage3"><span id="baloonText3" class="ecl-form-label"></span><br><span id="baloonSubText3" class="ecl-u-type-m"></span> <div class="crossToClose"><span class="ecl-form-label" onclick="closeBalloon(3)">x</span></div><div class="progressBar3" id="progressBar3"><div></div></div></div>
     <script>
       ECL.autoInit();
+       if (environment === 'STAGING') {
+		$("#showProd").show();
+		$("#showStaging").hide();
+	  } else if (environment === 'PROD') {
+	    $("#showProd").hide();
+		$("#showStaging").show();
+	  }
     </script>
     <script src="../js/menu.js"></script>
   </body>

--- a/test-selection/index.html
+++ b/test-selection/index.html
@@ -150,8 +150,9 @@
                                 <ul class="ecl-menu__sublist">
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
                                             class="ecl-menu__sublink">Other instances</span></li>
-                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a onclick= "location.href=stagingURL" href="#"
-                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a></li>
+                                    <li class="ecl-menu__subitem" data-ecl-menu-subitem="true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a id="showStaging" onclick= "location.href=stagingURL" href="#"
+                                                                                                                                class="ecl-link ecl-link--standalone ecl-menu__sublink">Staging instance</a>
+                                        <a id="showProd" onclick= "location.href=productionURL" href="#" class="ecl-link ecl-link--standalone ecl-menu__sublink">Production instance</a></li><li></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span class="ecl-menu__sublink">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></li>
                                     <li class="ecl-menu__subitem" data-ecl-menu-subitem="true"><span
@@ -5678,6 +5679,14 @@
       let selectAnnex3 = new vanillaSelectBox("#select-annex-3", {
         placeHolder: "-", search: true, disableSelectAll: true, maxWidth: 250
       });
+
+       if (environment === 'STAGING') {
+		$("#showProd").show();
+		$("#showStaging").hide();
+	  } else if (environment === 'PROD') {
+	    $("#showProd").hide();
+		$("#showStaging").show();
+	  }
     </script>
 
     <script src="../js/menu.js"></script>


### PR DESCRIPTION
Issue #120 - In order to manage 'Staging instance' label in the menu (as requested by Marco) it has been added a new variable in config.js **productionURL** (independent from environment).
In Staging the label in the menu will be 'Production instance' with the link to the Production.
In Production the label will be 'Staging instance' with the link to Staging (as it is now).

This change will be managed from the already existing variable in the config.js **environment**, that change from one environment to another.