### PR TITLE
Fix on the prefill for the label on the Network Service Test, CC 4b

### DIFF
--- a/js/selection/controller.js
+++ b/js/selection/controller.js
@@ -91,6 +91,7 @@ ngApp.controller('myValidatorController', function($scope) {
 			$scope.select.metadataAdvancedCommonRequirementsNetworkService = true;
 			$scope.select.metadataAdvancedConformanceClass3 = true;
 			$scope.select.metadataAdvancedConformanceClass4 = true;
+			$scope.select.metadataAdvancedConformanceClass4b = true;
 		}
 		if (metadataRecords == "spatialdataservice") {
 			$("#metadata-20-spatialdataservice-options-1").prop("checked", true);
@@ -901,6 +902,7 @@ ngApp.controller('myValidatorController', function($scope) {
 	$scope.select.metadataAdvancedCommonRequirementsNetworkService = true;
 	$scope.select.metadataAdvancedConformanceClass3 = true;
 	$scope.select.metadataAdvancedConformanceClass4 = true;
+	$scope.select.metadataAdvancedConformanceClass4b = true;
 	$scope.select.metadataAdvancedCommonRequirementsSpatialDataService = true;
 	$scope.select.metadataAdvancedConformanceClass5 = true;
 	$scope.select.metadataAdvancedConformanceClass6 = false;


### PR DESCRIPTION
When the Network Service Test is selected, if we open the Advanced Options, then the prefilled label was not always populated.
This PR is related to the issue #134 